### PR TITLE
Timeblocks

### DIFF
--- a/contracts/timeblocks.clar
+++ b/contracts/timeblocks.clar
@@ -1,6 +1,7 @@
 ;; Constants
 (define-constant TOKEN_SUPPLY u1000000) ;; Maximum supply of reward tokens
 (define-constant REWARD_AMOUNT u10) ;; Tokens awarded per completed session
+(define-constant BREAK_TIME u5) ;; Time in minutes after which the break reminder will occur
 
 ;; Data Variables
 (define-data-var total-tokens-minted uint u0) ;; Tracks the total tokens minted
@@ -57,7 +58,10 @@
       ;; Check token supply limits
       (if (> (var-get total-tokens-minted) TOKEN_SUPPLY)
         (err u1000) ;; Error: Maximum token supply reached
-        (ok { message: "Session completed, duration recorded, and rewards issued!" })
+        (begin
+          ;; Notify user to take a break after completing a session
+          (ok { message: "Session completed, duration recorded, rewards issued! Take a break now. Stay refreshed!" })
+        )
       )
     )
   )

--- a/contracts/timeblocks.clar
+++ b/contracts/timeblocks.clar
@@ -1,30 +1,98 @@
+;; Constants
+(define-constant TOKEN_SUPPLY u1000000) ;; Maximum supply of reward tokens
+(define-constant REWARD_AMOUNT u10) ;; Tokens awarded per completed session
 
-;; title: timeblocks
-;; version:
-;; summary:
-;; description:
+;; Data Variables
+(define-data-var total-tokens-minted uint u0) ;; Tracks the total tokens minted
+(define-data-var total-sessions uint u0) ;; Tracks the total sessions completed
+(define-data-var contract-owner principal tx-sender) ;; Contract owner
 
-;; traits
-;;
+;; Data Maps
+(define-map user-sessions principal uint) ;; Tracks completed sessions per user
+(define-map user-rewards principal uint) ;; Tracks reward tokens per user
 
-;; token definitions
-;;
+;; Public Functions
 
-;; constants
-;;
+;; Start a Pomodoro session
+(define-public (start-session)
+  (begin
+    ;; Log session start (for user tracking)
+    (ok { message: "Pomodoro session started. Stay focused!" })
+  )
+)
 
-;; data vars
-;;
+;; Complete a session and reward tokens
+(define-public (complete-session)
+  (let
+    (
+      (caller tx-sender) ;; Current user
+      (current-sessions (default-to u0 (map-get? user-sessions caller))) ;; User's completed sessions
+      (current-rewards (default-to u0 (map-get? user-rewards caller))) ;; User's current reward balance
+    )
+    (begin
+      ;; Update user data
+      (map-set user-sessions caller (+ current-sessions u1))
+      (map-set user-rewards caller (+ current-rewards REWARD_AMOUNT))
 
-;; data maps
-;;
+      ;; Increment global metrics
+      (var-set total-sessions (+ (var-get total-sessions) u1))
+      (var-set total-tokens-minted (+ (var-get total-tokens-minted) REWARD_AMOUNT))
 
-;; public functions
-;;
+      ;; Check token supply limits
+      (if (> (var-get total-tokens-minted) TOKEN_SUPPLY)
+        (err u1000) ;; Error: Maximum token supply reached
+        (ok { message: "Session completed and rewards issued!" })
+      )
+    )
+  )
+)
 
-;; read only functions
-;;
+;; Claim accumulated rewards
+(define-public (claim-rewards)
+  (let
+    (
+      (caller tx-sender) ;; Current user
+      (reward-balance (default-to u0 (map-get? user-rewards caller))) ;; User's reward balance
+    )
+    (begin
+      (if (is-eq reward-balance u0)
+        (err u4000) ;; Error: No rewards to claim
+        (begin
+          ;; Reset rewards to zero after claiming
+          (map-set user-rewards caller u0)
+          (ok { claimed: reward-balance, message: "Rewards successfully claimed!" })
+        )
+      )
+    )
+  )
+)
 
-;; private functions
-;;
+;; Read-Only Functions
 
+;; Get total completed sessions for a user
+(define-read-only (get-session-count (user principal))
+  (default-to u0 (map-get? user-sessions user))
+)
+
+;; Get reward balance for a user
+(define-read-only (get-reward-balance (user principal))
+  (default-to u0 (map-get? user-rewards user))
+)
+
+;; Get global stats: total sessions and minted tokens
+(define-read-only (get-global-stats)
+  {
+    total-sessions: (var-get total-sessions),
+    total-tokens-minted: (var-get total-tokens-minted)
+  }
+)
+
+;; Private Functions
+
+;; Ensure only the contract owner can perform certain actions
+(define-private (only-owner)
+  (if (is-eq tx-sender (var-get contract-owner))
+    true ;; If the sender is the owner, return true
+    false ;; Otherwise, return false
+  )
+)


### PR DESCRIPTION
Pull Request Description:
Title: Add Pomodoro Timer with Session Tracking and Break Notification

Description:

This pull request introduces a Pomodoro timer contract built on the Stacks blockchain. The contract tracks user sessions, rewards tokens for each completed Pomodoro session, and includes notifications for users to take a break after completing each session.

Features:
Pomodoro Session Management: Users can start and complete Pomodoro sessions. Each completed session increments a session count and records the session duration.
Reward System: Users earn reward tokens (u10) for each completed session. Tokens are minted in accordance with a maximum supply limit (TOKEN_SUPPLY), and the contract ensures that the token supply doesn't exceed this limit.
Session Duration Tracking: The contract tracks the duration of each session for every user.
Break Notification: After completing a Pomodoro session, users are notified to take a break. This helps enhance the Pomodoro method by encouraging rest after focused work.
Reward Claims: Users can claim their accumulated reward tokens, and the contract ensures users cannot claim rewards if they have none.
Global Stats: A read-only function provides the global count of total sessions completed and the total tokens minted.
Technical Details:
Contract Constants:

TOKEN_SUPPLY: Defines the maximum token supply.
REWARD_AMOUNT: Defines the reward tokens granted per session completion.
BREAK_TIME: Introduces a simulated break time (in minutes) after each session.
Data Variables:

Tracks the total sessions, total minted tokens, and the contract owner.
Data Maps:

Stores user-specific data such as session counts, reward balances, session start times, and session durations.
Functionality:
start-session: Starts a Pomodoro session for the user by incrementing their session count.
complete-session: Completes the user's session, calculates the session duration, rewards tokens, and issues a break reminder.
claim-rewards: Allows users to claim their reward tokens, with safeguards to prevent claims if no rewards are accumulated.
get-session-count, get-reward-balance, get-session-duration: Read-only functions to get session and reward data for a user.
get-global-stats: Retrieves global statistics for total sessions and minted tokens.
Changes:
Added Pomodoro session tracking with reward issuance and session duration calculation.
Implemented a break reminder message after each session completion.
Integrated a reward claim system with proper checks and balances for token distribution.
Testing:
The contract has been tested using clarinet check and passes successfully without any errors or warnings.
Future Improvements:
Break Timer: Integrating an actual timer feature for session breaks in future versions.
UI/UX Support: Integration with front-end applications to display session progress and reward tracking.
